### PR TITLE
bugfix: 兼容axios中对responseType的设置

### DIFF
--- a/src/mock/xhr/xhr.js
+++ b/src/mock/xhr/xhr.js
@@ -264,6 +264,7 @@ Util.extend(MockXMLHttpRequest.prototype, {
 
         // 原生 XHR
         if (!this.match) {
+            this.custom.xhr.responseType = this.responseType //复制原始XHR的responseType
             this.custom.xhr.send(data)
             return
         }


### PR DESCRIPTION
因为MockXMLHttpRequest覆盖了原始的window.XMLHttpRequest，this.custom.xhr.send调用之前，原生的XMLHttpRequest.responseType为空串，最终导致XMLHttpRequest获得的response和responseText一样都是string类型。

`An empty responseType string is treated the same as "text", the default type`
https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseType

#171